### PR TITLE
fix packing of date objects in hashmaps

### DIFF
--- a/rjson.js
+++ b/rjson.js
@@ -125,6 +125,8 @@ var RJSON = (function() {
                 return value;
             } else if (isArray(value)) {
                 return encodeArray(value);
+            } else if (isDate(value)) {
+                return value.toString();
             } else {
                 return encodeObject(value);
             }
@@ -239,6 +241,10 @@ var RJSON = (function() {
 
     function _isArray(obj) {
         return toString.apply(obj) === '[object Array]';
+    }
+
+    function isDate(val) {
+      return (val instanceof Date && isNaN(val.valueOf()) === false);
     }
 
     return {

--- a/test/tests.js
+++ b/test/tests.js
@@ -46,6 +46,9 @@ test('Hashmaps', function() {
     // but restored document will be fully identical to the original document
     testPacked({'test': [{'b': '1', 'a': '1'}, {'b': '2', 'a': '2'}]},
               '{"test":[{"a":"1","b":"1"},[2,"2","2"]]}');
+    dt = new Date()
+    testPacked({'ts': dt},
+              '{"ts":"'+ dt.toString() +'"}');
 
 });
 


### PR DESCRIPTION
packing of objects with `new Date()` objects as values results in the value being converted to `{}`. this change converts date objects to timestamp strings
